### PR TITLE
Fix PE-D bugs: storage corruption, Ctrl+C data loss, crash on save failure

### DIFF
--- a/src/main/java/command/CommandRunner.java
+++ b/src/main/java/command/CommandRunner.java
@@ -108,7 +108,7 @@ public class CommandRunner {
             try {
                 Storage.saveState(this.skuList);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                Ui.printError("Failed to save data: " + e.getMessage());
             }
             Ui.printGoodbye();
             isRunning = false;

--- a/src/main/java/storage/Storage.java
+++ b/src/main/java/storage/Storage.java
@@ -2,12 +2,17 @@ package storage;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import sku.SKU;
 import sku.SKUList;
+import skutask.SKUTask;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.FileReader;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Handles persistent storage of the warehouse state by serializing and
@@ -59,12 +64,45 @@ public class Storage {
             SKUList loadedSkus = gson.fromJson(reader, SKUList.class);
 
             if (loadedSkus != null) {
+                if (isCorrupted(loadedSkus)) {
+                    System.out.println("[WARNING] Corrupted or outdated JSON format detected. "
+                            + "Starting with an empty warehouse.");
+                    return;
+                }
                 skuList.getSKUList().addAll(loadedSkus.getSKUList());
             }
         } catch (IOException e) {
             System.out.println("[ERROR] Error loading: " + e.getMessage());
         } catch (com.google.gson.JsonSyntaxException e) {
-            System.out.println("[ERROR] Corrupted or outdated JSON format. Please delete!" + FILE_PATH);
+            System.out.println("[WARNING] Corrupted or outdated JSON format. Please delete! " + FILE_PATH);
         }
+    }
+
+    /**
+     * Checks whether the loaded SKUList contains any corrupted data,
+     * such as SKUs with a null location or tasks with an invalid date format.
+     *
+     * @param loadedSkus The deserialized SKUList to validate.
+     * @return True if any corruption is detected, false otherwise.
+     */
+    private static boolean isCorrupted(SKUList loadedSkus) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        for (SKU sku : loadedSkus.getSKUList()) {
+            if (sku.getSKULocation() == null) {
+                return true;
+            }
+            for (SKUTask task : sku.getSKUTaskList().getSKUTaskList()) {
+                String dueDate = task.getSKUTaskDueDate();
+                if (dueDate == null) {
+                    return true;
+                }
+                try {
+                    LocalDate.parse(dueDate, formatter);
+                } catch (DateTimeParseException e) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/ui/ItemTasker.java
+++ b/src/main/java/ui/ItemTasker.java
@@ -4,6 +4,7 @@ import command.CommandRunner;
 import command.ParsedCommand;
 import exception.ItemTaskerException;
 import sku.SKUList;
+import storage.Storage;
 
 import java.io.IOException;
 
@@ -26,6 +27,16 @@ public class ItemTasker {
         SKUList skuList = new SKUList();
         Ui ui = new Ui();
         CommandRunner runner = new CommandRunner(skuList);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (runner.isRunning()) {
+                try {
+                    Storage.saveState(skuList);
+                } catch (IOException e) {
+                    System.out.println("[ERROR] Failed to save data on exit: " + e.getMessage());
+                }
+            }
+        }));
 
         Ui.printWelcome();
 


### PR DESCRIPTION
## Summary
- **#254**: Added JVM shutdown hook in `ItemTasker.java` to call `Storage.saveState()` on forced termination (Ctrl+C), preventing data loss
- **#239 / #245**: Added `isCorrupted()` validation in `Storage.loadState()` — detects null `skuLocation` and invalid `yyyy-MM-dd` date formats post-deserialization; resets to empty warehouse with a warning instead of loading bad data
- **#210**: Fixed missing space in error message (`Please delete! Data/storage.json`)
- **#203**: Replaced `throw new RuntimeException(e)` on save failure with a graceful `[ERROR] Failed to save data: ...` message so the app exits cleanly

## Test plan
- [ ] Add SKUs/tasks, Ctrl+C the app, relaunch — data should persist
- [ ] Manually delete `skuLocation` from `storage.json`, relaunch — should warn and start empty, no crash on `viewmap`
- [ ] Set an invalid date (e.g. `2025-99-99`) in `storage.json`, relaunch — should warn and start empty
- [ ] Run app in a read-only directory, type `bye` — should print error message and exit cleanly (no stack trace)
- [ ] Verify corrupted JSON error message includes a space before the file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)